### PR TITLE
docs: Switch to developer quick start instructions; clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ run-jupyter:
 
 ## run-web-app:                 runs the FastAPI api with hot reloading
 .PHONY: run-web-app
-run-app-dev:
+run-web-app:
 	 PYTHONPATH=$(realpath .) uvicorn ${PACKAGE_NAME}.api.comments:app --reload
 
 #################

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The API is hosted at `https://api.unstructured.io`.
 	  * `pyenv install 3.8.13`
   * Linux instructions are available [here](https://github.com/Unstructured-IO/community#linux).
 
-	Create a virtualenv to work in and activate it, e.g. for one named `sec-filings`:
+  * Create a virtualenv to work in and activate it, e.g. for one named `oer`:
 
-	`pyenv  virtualenv 3.8.13 sec-filings` <br />
-	`pyenv activate sec-filings`
+	`pyenv  virtualenv 3.8.13 oer` <br />
+	`pyenv activate oer`
 
 * Run `make install`
 * Start a local jupyter notebook server with `make run-jupyter` <br />


### PR DESCRIPTION
### Summary

Updates the installation section to use the same quick start format as `pipeline-sec-filings`. Also updates the `Makefile` for consistency with `pipeline-sec-filings`.

### Testing

The following two make commands should work:

- `make run-jupyter`
- `make run-web-app`