### PR TITLE
fix: Update number in notebook

### DIFF
--- a/pipeline-notebooks/pipeline-raters.ipynb
+++ b/pipeline-notebooks/pipeline-raters.ipynb
@@ -552,7 +552,7 @@
    "id": "6b9f4b45",
    "metadata": {},
    "source": [
-    "## Section 6: Define the API\n",
+    "## Section 5: Define the API\n",
     "\n",
     "Finally, we define the API for the pipeline. Any cell that has a `# pipeline-api` comment is included in the API definition. The `pipeline_api` function is the function that's called when the API is invoked."
    ]


### PR DESCRIPTION
### Summary

Corrects the numbering of the sections in the pipeline notebook. Previously, the number jumped from Section 4 to Section 6.