### PR TITLE
build(deps): pin `opencv-python` for rhel7 installation

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,3 +7,8 @@ requests
 
 # NOTE(robinson) - Required pins for security scans
 jupyter-core>=4.11.2
+
+# NOTE(robinson) - later versions of opencv-python cause installation issues
+# on RHEL7. We can remove this pin once the following issue from 12/2022 is resolved
+# ref: https://github.com/opencv/opencv-python/issues/772
+opencv-python==4.6.0.66

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -158,8 +158,10 @@ numpy==1.24.0
     #   torchvision
 omegaconf==2.3.0
     # via effdet
-opencv-python==4.7.0.68
-    # via layoutparser
+opencv-python==4.6.0.66
+    # via
+    #   -r requirements/base.in
+    #   layoutparser
 openpyxl==3.0.10
     # via unstructured
 packaging==21.3


### PR DESCRIPTION
### Summary

Pinning the version of `opencv-python` due to installation errors on RHEL7. We can remove the pin once [this issue](https://github.com/opencv/opencv-python/issues/772) is resolved.

### Testing

Build should continue to pass and you should be able to install the pipeline on RHEL7.