### PR TITLE
build(deps): bump `unstructured` to 0.4.1; unpin `opencv-python`

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
-unstructured[local-inference]>=0.4.0
+unstructured[local-inference]>=0.4.1
 unstructured-inference>=0.2.1
 unstructured_api_tools==0.4.7
 
@@ -7,8 +7,3 @@ requests
 
 # NOTE(robinson) - Required pins for security scans
 jupyter-core>=4.11.2
-
-# NOTE(robinson) - later versions of opencv-python cause installation issues
-# on RHEL7. We can remove this pin once the following issue from 12/2022 is resolved
-# ref: https://github.com/opencv/opencv-python/issues/772
-opencv-python==4.6.0.66

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -160,8 +160,8 @@ omegaconf==2.3.0
     # via effdet
 opencv-python==4.6.0.66
     # via
-    #   -r requirements/base.in
     #   layoutparser
+    #   unstructured-inference
 openpyxl==3.0.10
     # via unstructured
 packaging==21.3
@@ -323,11 +323,11 @@ typing-extensions==4.3.0
     #   starlette
     #   torch
     #   torchvision
-unstructured[local-inference]==0.4.0
+unstructured[local-inference]==0.4.1
     # via -r requirements/base.in
 unstructured-api-tools==0.4.7
     # via -r requirements/base.in
-unstructured-inference==0.2.1
+unstructured-inference==0.2.3
     # via
     #   -r requirements/base.in
     #   unstructured


### PR DESCRIPTION
### Summary

Bumps `unstructured` since the updated version of unstructured includes the `opencv-python` pin.