### PR TITLE
chore: use --load with docker buildx

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -23,7 +23,7 @@ elif ! [ -r "$SSH_PRIVATE_KEY" ]; then
 fi
 
 
-DOCKER_BUILDKIT=1 docker buildx build --platform=linux/amd64 -f docker/Dockerfile"${BUILD_TYPE}" \
+DOCKER_BUILDKIT=1 docker buildx build --load --platform=linux/amd64 -f docker/Dockerfile"${BUILD_TYPE}" \
   --build-arg PIP_VERSION="$PIP_VERSION" \
   --progress plain \
   --secret id=ssh_key,src="$SSH_PRIVATE_KEY" \


### PR DESCRIPTION
Use --load which is necessary with buildx sometimes to be
able to run the image. E.g., in github CI.

Consistency with https://github.com/Unstructured-IO/pipeline-template/pull/10
