### PR TITLE
feat: add name and position fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Run core tests
       run: |
         source .venv/bin/activate
-        sudo apt-get install --yes poppler-utils
+        sudo apt-get install --yes poppler-utils tesseract-ocr
         make test
         make check-coverage
         # NOTE(robinson) - temporarily disabling due to floating point differences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 0.0.1-dev1
+## 0.0.1-dev2
 
+* Adds rater and rated names and positions to extractions
 * Adds checkbox discovery
 * Adds option to run the inference API locally

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ and get the following JSON as the output:
       "character": "1LT X’s exceptional command presence and resilience lends itself to consistent mission accomplishment, good order and discipline, and a positive climate. 1LT X’s outstanding attitude and thirst for knowledge exceeds those around him which contributes to his overall exceptional character."
     },
     "referred": "No",
-    "performance": "PROFICIENT"
+    "performance": "PROFICIENT",
+    "name": "RAYMOND, BRIAN",
+    "position": "EXECUTIVE OFFICER"
   },
   "senior_rater": {
     "comments": "I currently senior rate Army Officers in this grade. 1LT X is #4 of the 44 Lieutenants I senior rated. 1LT X is an intelligent and creative Officer with the potential to progress in rank as a leader. 1LT X is ready for positions of increased responsibilities; he will excel as a Staff Officer followed by Company Command if given the opportunity. Select for Military Police Captains Career Course and promote to captain when eligible.",
@@ -76,11 +78,17 @@ and get the following JSON as the output:
       " Battalion AS3",
       " Battalion S4"
     ],
-    "potential": "HIGHLY QUALIFIED"
+    "potential": "HIGHLY QUALIFIED",
+    "name": "BERTL, ALAN",
+    "position": "BATTALION COMMANDER"
   },
   "intermediate_rater": {
-    "comments": "1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command."
-  }
+    "comments": "1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command.",
+    "name": "WOLFE, CRAG",
+    "position": ""
+  },
+  "rated_name": "ROBINSON, MATTHEW W",
+  "rated_position": ""
 }
 ```
 

--- a/pipeline-notebooks/pipeline-raters.ipynb
+++ b/pipeline-notebooks/pipeline-raters.ipynb
@@ -110,9 +110,10 @@
     "from unstructured_inference.inference.layout import (\n",
     "    process_data_with_model,\n",
     "    process_file_with_model,\n",
+    "    DocumentLayout,\n",
     ")\n",
     "\n",
-    "def partition_oer(\n",
+    "def get_layout(\n",
     "    filename=\"\",\n",
     "    file=None,\n",
     "    model=None\n",
@@ -122,8 +123,9 @@
     "        if file is None\n",
     "        else process_data_with_model(file, model)\n",
     "    )\n",
-    "    \n",
-    "    \n",
+    "    return layout\n",
+    "\n",
+    "def partition_oer(layout: DocumentLayout):\n",
     "    pages = []\n",
     "    for page in layout.pages:\n",
     "        pages.append({\"elements\": [el.to_dict() for el in page.elements]})\n",
@@ -143,8 +145,10 @@
     "    warnings.simplefilter(\"ignore\")\n",
     "    filename = get_filename(\"sample-docs\", \"fake-oer.pdf\")\n",
     "    with open(filename, \"rb\") as f:\n",
-    "        pages = partition_oer(filename=filename)[\"pages\"]\n",
-    "        cb_pages = partition_oer(filename=filename, model=\"checkbox\")[\"pages\"]"
+    "        layout = get_layout(filename=filename)\n",
+    "        pages = partition_oer(layout=layout)[\"pages\"]\n",
+    "        cb_layout = get_layout(filename=filename, model=\"checkbox\")\n",
+    "        cb_pages = partition_oer(layout=layout)[\"pages\"]"
    ]
   },
   {
@@ -205,12 +209,12 @@
     {
      "data": {
       "text/plain": [
-       "{'type': 'Unchecked',\n",
-       " 'coordinates': [[237.96682739257812, 352.9676818847656],\n",
-       "  [251.81820678710938, 352.9676818847656],\n",
-       "  [251.81820678710938, 365.15911865234375],\n",
-       "  [237.96682739257812, 365.15911865234375]],\n",
-       " 'text': ''}"
+       "{'type': 'Text',\n",
+       " 'coordinates': [[23.71831512451172, 476.9766540527344],\n",
+       "  [571.7439575195312, 476.9766540527344],\n",
+       "  [571.7439575195312, 549.2498779296875],\n",
+       "  [23.71831512451172, 549.2498779296875]],\n",
+       " 'text': 'c. SIGNIFICANT DUTIES AND RESPONSIBILITIES Personnel and Administration Officer (S1) for a training battalion in the U.S. Army reserve. Principal staff assistant to the battalion commander. Exercise staff supervisor in matters pertaining to strength management, personnel qualifications and evaluations, personnel assignment, clearance, recruiting, retention, and battalion administration. Responsible for the overall supervision of the battalion Personnel Administration Center (PAC) and its activities. Serves as commander of Headquarters and Headquarters Detachment. Additional duties include; Battalion Safety Officer, Equal Opportunity Officer, Records Management Officer, and Retention Officer.'}"
       ]
      },
      "execution_count": null,
@@ -268,7 +272,9 @@
     "\n",
     "BLOCK_TITLE_PATTTERN = (\n",
     "    r\"c. (SIGNIFICANT DUTIES AND RESPONSIBILITIES|COMMENTS ON POTENTIAL):?\"\n",
-    ")"
+    ")\n",
+    "\n",
+    "NAME_OCR_WHITESPACE = r\"\\.?_*[\\n\\r\\s]*\""
    ]
   },
   {
@@ -298,11 +304,73 @@
    "id": "1d4d9722",
    "metadata": {},
    "source": [
-    "## Section 4: Custom Brick Combos\n",
+    "## Section 4: Custom Brick Combos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66a0c804",
+   "metadata": {},
+   "source": [
+    "#### Rater Names and Positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90b36bc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pipeline-api\n",
     "\n",
+    "from unstructured.cleaners.core import clean_postfix\n",
+    "from unstructured_inference.inference.layout import TextBlock, PageLayout\n",
+    "from layoutparser import Rectangle\n",
+    "\n",
+    "rated_loc = [0.04084967320261438, 0.10227272727272728, 0.40522875816993464, 0.11994949494949494]\n",
+    "rated_position_loc = [0.04084967320261438, 0.5782828282828283, 0.49019607843137253, 0.5909090909090909]\n",
+    "rater_loc = [0.04084967320261438, 0.2196969696969697, 0.4852941176470588, 0.23737373737373738]\n",
+    "rater_position_loc = [0.7581699346405228, 0.2196969696969697, 0.9575163398692811, 0.23737373737373738]\n",
+    "intermediate_loc = [0.04084967320261438, 0.2828282828282828, 0.4852941176470588, 0.3005050505050505]\n",
+    "intermediate_position_loc = [0.7581699346405228, 0.2828282828282828, 0.9575163398692811, 0.3005050505050505]\n",
+    "senior_loc = [0.04084967320261438, 0.34595959595959597, 0.40522875816993464, 0.36363636363636365]\n",
+    "senior_position_loc = [0.7581699346405228, 0.34595959595959597, 0.9575163398692811, 0.36363636363636365]\n",
+    "\n",
+    "def get_field_by_ocr(page: PageLayout, loc: list):\n",
+    "    height = page.image.height\n",
+    "    width = page.image.width\n",
+    "    multiplier = [width, height, width, height]\n",
+    "    coords = [rel_coord * mult for rel_coord, mult in zip(loc, multiplier)]\n",
+    "    rect = Rectangle(*coords)\n",
+    "    text_block = TextBlock(rect)\n",
+    "    field_contents = page.ocr(text_block)\n",
+    "    field_contents = clean_postfix(field_contents, NAME_OCR_WHITESPACE)\n",
+    "    return field_contents\n",
+    "\n",
+    "def get_names_and_positions(page: PageLayout):\n",
+    "    loc_dict = {\n",
+    "        'rated_name': rated_loc,\n",
+    "        'rated_position': rated_position_loc,\n",
+    "        'rater_name': rater_loc,\n",
+    "        'rater_position': rater_position_loc,\n",
+    "        'intermediate_name': intermediate_loc,\n",
+    "        'intermediate_position': intermediate_position_loc,\n",
+    "        'senior_name': senior_loc,\n",
+    "        'senior_position': senior_position_loc,\n",
+    "    }\n",
+    "    name_dict = {name: get_field_by_ocr(page, loc) for name, loc in loc_dict.items()}\n",
+    "    return name_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad054519",
+   "metadata": {},
+   "source": [
     "#### Senior Rater Comments\n",
     "\n",
-    "You can also use combinations of bricks to isolate important sections of text. Here, we use the `extract_text_after`, `extract_text_before`, and `clean_postfix` bricks to identify the section of text that corresponds to the senior rater comments in the OER."
+    "You can also use combinations of bricks to isolate important sections of text. Here, we use the `extract_text_after`, `extract_text_before`, and `clean_postfix` bricks to identify the section of text that corresponds to the senior rater comments in the OER.\n"
    ]
   },
   {
@@ -339,7 +407,6 @@
    "outputs": [],
    "source": [
     "# pipeline-api\n",
-    "from unstructured.cleaners.core import clean_postfix\n",
     "from unstructured.cleaners.extract import (\n",
     "    extract_text_after, extract_text_before\n",
     ")\n",
@@ -418,7 +485,7 @@
    "source": [
     "#### Rater Sections\n",
     "\n",
-    "In this second section, we use a another combination of breaks to extract and clean the rater comments sections from the second page of the OER."
+    "In this second section, we use a another combination of bricks to extract and clean the rater comments sections from the second page of the OER."
    ]
   },
   {
@@ -685,11 +752,15 @@
     "    file_content_type=None,\n",
     "    filename=None,\n",
     "):\n",
-    "    pages = partition_oer(file=file)[\"pages\"]\n",
+    "    layout = get_layout(file=file)\n",
+    "    pages = partition_oer(layout=layout)[\"pages\"]\n",
     "    narrative = structure_oer(pages)\n",
-    "    \n",
+    "\n",
+    "    name_position_dict = get_names_and_positions(layout.pages[0])\n",
+    "\n",
     "    file.seek(0)\n",
-    "    checkbox_pages = partition_oer(file=file, model=\"checkbox\")[\"pages\"]\n",
+    "    cb_layout = get_layout(file=file, model=\"checkbox\")\n",
+    "    checkbox_pages = partition_oer(layout=cb_layout)[\"pages\"]\n",
     "\n",
     "    checkbox = structure_checkboxes(checkbox_pages)\n",
     "    for key in [\"referred\", \"comments\", \"supplementary_review\", \"performance\"]:\n",
@@ -697,6 +768,14 @@
     "            narrative[\"rater\"][key] = checkbox[key]\n",
     "    if \"senior_rater\" in narrative and \"potential\" in checkbox:\n",
     "        narrative[\"senior_rater\"][\"potential\"] = checkbox[\"potential\"]\n",
+    "    narrative[\"rated_name\"] = name_position_dict[\"rated_name\"]\n",
+    "    narrative[\"rated_position\"] = name_position_dict[\"rated_position\"]\n",
+    "    narrative[\"rater\"][\"name\"] = name_position_dict[\"rater_name\"]\n",
+    "    narrative[\"rater\"][\"position\"] = name_position_dict[\"rater_position\"]\n",
+    "    narrative[\"intermediate_rater\"][\"name\"] = name_position_dict[\"intermediate_name\"]\n",
+    "    narrative[\"intermediate_rater\"][\"position\"] = name_position_dict[\"intermediate_position\"]\n",
+    "    narrative[\"senior_rater\"][\"name\"] = name_position_dict[\"senior_name\"]\n",
+    "    narrative[\"senior_rater\"][\"position\"] = name_position_dict[\"senior_position\"]\n",
     "\n",
     "    return narrative"
    ]
@@ -735,7 +814,9 @@
       "            \"character\": \"1LT X\\u2019s exceptional command presence and resilience lends itself to consistent mission accomplishment, good order and discipline, and a positive climate. 1LT X\\u2019s outstanding attitude and thirst for knowledge exceeds those around him which contributes to his overall exceptional character.\"\n",
       "        },\n",
       "        \"referred\": \"No\",\n",
-      "        \"performance\": \"PROFICIENT\"\n",
+      "        \"performance\": \"PROFICIENT\",\n",
+      "        \"name\": \"RAYMOND, BRIAN\",\n",
+      "        \"position\": \"EXECUTIVE OFFICER\"\n",
       "    },\n",
       "    \"senior_rater\": {\n",
       "        \"comments\": \"I currently senior rate Army Officers in this grade. 1LT X is #4 of the 44 Lieutenants I senior rated. 1LT X is an intelligent and creative Officer with the potential to progress in rank as a leader. 1LT X is ready for positions of increased responsibilities; he will excel as a Staff Officer followed by Company Command if given the opportunity. Select for Military Police Captains Career Course and promote to captain when eligible.\",\n",
@@ -744,11 +825,17 @@
       "            \" Battalion AS3\",\n",
       "            \" Battalion S4\"\n",
       "        ],\n",
-      "        \"potential\": \"HIGHLY QUALIFIED\"\n",
+      "        \"potential\": \"HIGHLY QUALIFIED\",\n",
+      "        \"name\": \"BERTL, ALAN\",\n",
+      "        \"position\": \"BATTALION COMMANDER\"\n",
       "    },\n",
       "    \"intermediate_rater\": {\n",
-      "        \"comments\": \"1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command.\"\n",
-      "    }\n",
+      "        \"comments\": \"1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command.\",\n",
+      "        \"name\": \"WOLFE, CRAG\",\n",
+      "        \"position\": \"\"\n",
+      "    },\n",
+      "    \"rated_name\": \"ROBINSON, MATTHEW W\",\n",
+      "    \"rated_position\": \"\"\n",
       "}\n"
      ]
     }

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 unstructured[local-inference]>=0.4.4
-unstructured-inference>=0.2.4
+unstructured-inference>=0.2.5
 unstructured_api_tools==0.4.7
 
 ratelimit

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,13 +11,13 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
-argilla==1.2.1
+argilla==1.3.0
     # via unstructured
 attrs==22.2.0
     # via jsonschema
 backoff==2.2.1
     # via argilla
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via nbconvert
 bleach==6.0.0
     # via nbconvert
@@ -38,9 +38,11 @@ click==8.1.3
     #   nltk
     #   unstructured-api-tools
     #   uvicorn
+coloredlogs==15.0.1
+    # via onnxruntime
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.0
+cryptography==39.0.1
     # via pdfminer-six
 cycler==0.11.0
     # via matplotlib
@@ -54,14 +56,18 @@ effdet==0.3.0
     # via layoutparser
 et-xmlfile==1.1.0
     # via openpyxl
-fastapi==0.89.1
+fastapi==0.92.0
     # via
     #   unstructured-api-tools
     #   unstructured-inference
 fastjsonschema==2.16.2
     # via nbformat
 filelock==3.9.0
-    # via huggingface-hub
+    # via
+    #   huggingface-hub
+    #   transformers
+flatbuffers==23.1.21
+    # via onnxruntime
 fonttools==4.38.0
     # via matplotlib
 h11==0.14.0
@@ -74,10 +80,13 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via argilla
-huggingface-hub==0.12.0
+huggingface-hub==0.12.1
     # via
     #   timm
+    #   transformers
     #   unstructured-inference
+humanfriendly==10.0
+    # via coloredlogs
 idna==3.4
     # via
     #   anyio
@@ -88,7 +97,9 @@ importlib-metadata==6.0.0
     #   jupyter-client
     #   nbconvert
 importlib-resources==5.10.2
-    # via jsonschema
+    # via
+    #   jsonschema
+    #   matplotlib
 iopath==0.1.10
     # via layoutparser
 jinja2==3.1.2
@@ -97,9 +108,11 @@ jinja2==3.1.2
     #   unstructured-api-tools
 joblib==1.2.0
     # via nltk
+jsons==1.6.3
+    # via unstructured-inference
 jsonschema==4.17.3
     # via nbformat
-jupyter-client==8.0.2
+jupyter-client==8.0.3
     # via nbclient
 jupyter-core==5.2.0
     # via
@@ -125,15 +138,17 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.6.3
+matplotlib==3.7.0
     # via pycocotools
-mistune==2.0.4
+mistune==2.0.5
     # via nbconvert
 monotonic==1.6
     # via argilla
-mypy==0.991
+mpmath==1.2.1
+    # via sympy
+mypy==1.0.1
     # via unstructured-api-tools
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via mypy
 nbclient==0.7.2
     # via nbconvert
@@ -151,18 +166,22 @@ numpy==1.23.5
     #   contourpy
     #   layoutparser
     #   matplotlib
+    #   onnxruntime
     #   opencv-python
     #   pandas
     #   pycocotools
     #   scipy
     #   torchvision
+    #   transformers
 omegaconf==2.3.0
     # via effdet
+onnxruntime==1.13.1
+    # via unstructured-inference
 opencv-python==4.6.0.66
     # via
     #   layoutparser
     #   unstructured-inference
-openpyxl==3.0.10
+openpyxl==3.1.1
     # via unstructured
 packaging==22.0
     # via
@@ -171,7 +190,9 @@ packaging==22.0
     #   limits
     #   matplotlib
     #   nbconvert
+    #   onnxruntime
     #   pytesseract
+    #   transformers
 pandas==1.5.3
     # via
     #   argilla
@@ -183,7 +204,7 @@ pdf2image==1.16.2
     # via layoutparser
 pdfminer-six==20221105
     # via pdfplumber
-pdfplumber==0.7.6
+pdfplumber==0.8.0
     # via layoutparser
 pillow==9.4.0
     # via
@@ -197,15 +218,17 @@ pillow==9.4.0
     #   unstructured
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via jupyter-core
 portalocker==2.7.0
     # via iopath
+protobuf==4.22.0
+    # via onnxruntime
 pycocotools==2.0.6
     # via effdet
 pycparser==2.21
     # via cffi
-pydantic==1.10.4
+pydantic==1.10.5
     # via
     #   argilla
     #   fastapi
@@ -242,18 +265,22 @@ pyyaml==6.0
     #   layoutparser
     #   omegaconf
     #   timm
+    #   transformers
     #   uvicorn
 pyzmq==25.0.0
     # via jupyter-client
 ratelimit==2.2.1
     # via -r requirements/base.in
 regex==2022.10.31
-    # via nltk
+    # via
+    #   nltk
+    #   transformers
 requests==2.28.2
     # via
     #   -r requirements/base.in
     #   huggingface-hub
     #   torchvision
+    #   transformers
     #   unstructured
 rfc3986[idna2008]==1.5.0
     # via httpx
@@ -271,14 +298,18 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-soupsieve==2.3.2.post1
+soupsieve==2.4
     # via beautifulsoup4
-starlette==0.22.0
+starlette==0.25.0
     # via fastapi
+sympy==1.11.1
+    # via onnxruntime
 timm==0.6.12
     # via effdet
 tinycss2==1.2.1
     # via nbconvert
+tokenizers==0.13.2
+    # via transformers
 tomli==2.0.1
     # via mypy
 torch==1.13.1
@@ -300,6 +331,7 @@ tqdm==4.64.1
     #   huggingface-hub
     #   iopath
     #   nltk
+    #   transformers
 traitlets==5.9.0
     # via
     #   jupyter-client
@@ -307,13 +339,15 @@ traitlets==5.9.0
     #   nbclient
     #   nbconvert
     #   nbformat
-types-requests==2.28.11.8
+transformers==4.26.1
+    # via unstructured-inference
+types-requests==2.28.11.13
     # via unstructured-api-tools
 types-ujson==5.7.0.0
     # via unstructured-api-tools
-types-urllib3==1.26.25.4
+types-urllib3==1.26.25.6
     # via types-requests
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   huggingface-hub
     #   iopath
@@ -323,11 +357,13 @@ typing-extensions==4.4.0
     #   starlette
     #   torch
     #   torchvision
-unstructured[local-inference]==0.4.4
+typish==1.9.3
+    # via jsons
+unstructured[local-inference]==0.4.11
     # via -r requirements/base.in
 unstructured-api-tools==0.4.7
     # via -r requirements/base.in
-unstructured-inference==0.2.4
+unstructured-inference==0.2.7
     # via
     #   -r requirements/base.in
     #   unstructured
@@ -353,9 +389,9 @@ wrapt==1.14.1
     # via
     #   argilla
     #   deprecated
-xlsxwriter==3.0.7
+xlsxwriter==3.0.8
     # via python-pptx
-zipp==3.12.0
+zipp==3.13.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,9 +29,9 @@ attrs==22.2.0
     # via jsonschema
 backcall==0.2.0
     # via ipython
-beautifulsoup4==4.11.1
+beautifulsoup4==4.11.2
     # via nbconvert
-black==22.12.0
+black==23.1.0
     # via -r requirements/dev.in
 bleach==6.0.0
     # via nbconvert
@@ -51,11 +51,11 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
-execnb==0.1.4
+execnb==0.1.5
     # via nbdev
 executing==1.2.0
     # via stack-data
-fastcore==1.5.27
+fastcore==1.5.28
     # via
     #   execnb
     #   ghapi
@@ -78,7 +78,7 @@ importlib-metadata==6.0.0
     #   nbconvert
 importlib-resources==5.10.2
     # via jsonschema
-ipykernel==6.21.0
+ipykernel==6.21.2
     # via
     #   ipywidgets
     #   jupyter
@@ -118,7 +118,7 @@ jsonschema[format-nongpl]==4.17.3
     #   nbformat
 jupyter==1.0.0
     # via -r requirements/dev.in
-jupyter-client==8.0.2
+jupyter-client==8.0.3
     # via
     #   ipykernel
     #   jupyter-console
@@ -127,13 +127,14 @@ jupyter-client==8.0.2
     #   nbclient
     #   notebook
     #   qtconsole
-jupyter-console==6.4.4
+jupyter-console==6.5.1
     # via jupyter
 jupyter-core==5.2.0
     # via
     #   -r requirements/dev.in
     #   ipykernel
     #   jupyter-client
+    #   jupyter-console
     #   jupyter-server
     #   nbclassic
     #   nbclient
@@ -143,7 +144,7 @@ jupyter-core==5.2.0
     #   qtconsole
 jupyter-events==0.6.3
     # via jupyter-server
-jupyter-server==2.1.0
+jupyter-server==2.3.0
     # via
     #   nbclassic
     #   notebook-shim
@@ -163,11 +164,11 @@ matplotlib-inline==0.1.6
     #   ipython
 mccabe==0.7.0
     # via flake8
-mistune==2.0.4
+mistune==2.0.5
     # via nbconvert
-mypy==0.991
+mypy==1.0.1
     # via -r requirements/dev.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
@@ -181,7 +182,7 @@ nbconvert==7.2.9
     #   jupyter-server
     #   nbclassic
     #   notebook
-nbdev==2.3.9
+nbdev==2.3.12
     # via -r requirements/dev.in
 nbformat==5.7.3
     # via
@@ -192,6 +193,7 @@ nbformat==5.7.3
     #   notebook
 nest-asyncio==1.5.6
     # via
+    #   ipykernel
     #   nbclassic
     #   notebook
 notebook==6.5.2
@@ -200,6 +202,7 @@ notebook-shim==0.2.2
     # via nbclassic
 packaging==23.0
     # via
+    #   black
     #   build
     #   fastcore
     #   ghapi
@@ -217,11 +220,11 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via -r requirements/dev.in
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via
     #   black
     #   jupyter-core
@@ -262,7 +265,7 @@ python-dateutil==2.8.2
     # via
     #   arrow
     #   jupyter-client
-python-json-logger==2.0.4
+python-json-logger==2.0.6
     # via jupyter-events
 pyyaml==6.0
     # via
@@ -272,6 +275,7 @@ pyzmq==25.0.0
     # via
     #   ipykernel
     #   jupyter-client
+    #   jupyter-console
     #   jupyter-server
     #   nbclassic
     #   notebook
@@ -302,7 +306,7 @@ six==1.16.0
     #   rfc3339-validator
 sniffio==1.3.0
     # via anyio
-soupsieve==2.3.2.post1
+soupsieve==2.4
     # via beautifulsoup4
 stack-data==0.6.2
     # via ipython
@@ -335,6 +339,7 @@ traitlets==5.9.0
     #   ipython
     #   ipywidgets
     #   jupyter-client
+    #   jupyter-console
     #   jupyter-core
     #   jupyter-events
     #   jupyter-server
@@ -345,7 +350,7 @@ traitlets==5.9.0
     #   nbformat
     #   notebook
     #   qtconsole
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   black
     #   mypy
@@ -361,7 +366,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.5.0
+websocket-client==1.5.1
     # via jupyter-server
 wheel==0.38.4
     # via
@@ -369,7 +374,7 @@ wheel==0.38.4
     #   pip-tools
 widgetsnbextension==4.0.5
     # via ipywidgets
-zipp==3.12.0
+zipp==3.13.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 attrs==22.2.0
     # via pytest
-black==22.12.0
+black==23.1.0
     # via -r requirements/test.in
 click==8.1.3
     # via
@@ -22,17 +22,19 @@ iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
-mypy==0.991
+mypy==1.0.1
     # via -r requirements/test.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
 packaging==23.0
-    # via pytest
+    # via
+    #   black
+    #   pytest
 pathspec==0.11.0
     # via black
-platformdirs==2.6.2
+platformdirs==3.0.0
     # via black
 pluggy==1.0.0
     # via pytest
@@ -50,7 +52,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   black
     #   mypy

--- a/test_oer/api/test_raters.py
+++ b/test_oer/api/test_raters.py
@@ -33,22 +33,22 @@ def fake_structured_oer():
             "referred": "No",
             "performance": "PROFICIENT",
             "name": "RAYMOND, BRIAN",
-            "position": "EXECUTIVE OFFICER"
+            "position": "EXECUTIVE OFFICER",
         },
         "senior_rater": {
             "comments": "I currently senior rate Army Officers in this grade. 1LT X is #4 of the 44 Lieutenants I senior rated. 1LT X is an intelligent and creative Officer with the potential to progress in rank as a leader. 1LT X is ready for positions of increased responsibilities; he will excel as a Staff Officer followed by Company Command if given the opportunity. Select for Military Police Captains Career Course and promote to captain when eligible.",  # noqa: E501
             "next_assignment": ["Battalion FDO", " Battalion AS3", " Battalion S4"],
             "potential": "HIGHLY QUALIFIED",
             "name": "BERTL, ALAN",
-            "position": "BATTALION COMMANDER"
+            "position": "BATTALION COMMANDER",
         },
         "intermediate_rater": {
             "comments": "1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command.",  # noqa: E501
             "name": "WOLFE, CRAG",
-            "position": ""
+            "position": "",
         },
         "rated_name": "ROBINSON, MATTHEW W",
-        "rated_position": ""
+        "rated_position": "",
     }
 
 

--- a/test_oer/api/test_raters.py
+++ b/test_oer/api/test_raters.py
@@ -32,15 +32,23 @@ def fake_structured_oer():
             },
             "referred": "No",
             "performance": "PROFICIENT",
+            "name": "RAYMOND, BRIAN",
+            "position": "EXECUTIVE OFFICER"
         },
         "senior_rater": {
             "comments": "I currently senior rate Army Officers in this grade. 1LT X is #4 of the 44 Lieutenants I senior rated. 1LT X is an intelligent and creative Officer with the potential to progress in rank as a leader. 1LT X is ready for positions of increased responsibilities; he will excel as a Staff Officer followed by Company Command if given the opportunity. Select for Military Police Captains Career Course and promote to captain when eligible.",  # noqa: E501
             "next_assignment": ["Battalion FDO", " Battalion AS3", " Battalion S4"],
             "potential": "HIGHLY QUALIFIED",
+            "name": "BERTL, ALAN",
+            "position": "BATTALION COMMANDER"
         },
         "intermediate_rater": {
-            "comments": "1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command."  # noqa: E501
+            "comments": "1LT X is #2 of the 20 Lieutenants I intermediate rated. He is an asset for the future and will progress further in his military career. Keep assigning him to demanding position and select him for the Military Police Captains Career Course now. Promote ahead of peers to Captain and select him for the next Company Command.",  # noqa: E501
+            "name": "WOLFE, CRAG",
+            "position": ""
         },
+        "rated_name": "ROBINSON, MATTHEW W",
+        "rated_position": ""
     }
 
 


### PR DESCRIPTION
Added extraction of names and positions for the raters and rated. The sections didn't come out in an easy-to-extract way in the normal pipeline, so I OCR'd them using the locations of the fields. Despite this, one of the fields (intermediate rater position) wasn't extracted, and I think this is because the way it was rendered internally, the tops of the letters were slightly chopped off (so in my mind this is forgivable until/unless we can fix the rendering).

#### Testing:
```python
from prepline_oer.api.raters import get_field_by_ocr, intermediate_loc, get_layout

layout = get_layout('sample-docs/fake-oer.pdf')
get_field_by_ocr(layout.pages[0], intermediate_loc) # Output should be 'WOLFE, CRAG'

```

