### PR TITLE
chore: bump deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install-base: install-base-pip-packages
 
 ## install:                     installs all test and dev requirements
 .PHONY: install
-install: install-base install-test install-dev install-detectron2
+install: install-base install-detectron2 install-test install-dev
 
 .PHONY: install-base-pip-packages
 install-base-pip-packages:

--- a/prepline_oer/api/app.py
+++ b/prepline_oer/api/app.py
@@ -6,21 +6,14 @@
 
 from fastapi import FastAPI, Request, status
 
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_remote_address
-
 from .raters import router as raters_router
 
 
-limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(
     title="Unstructured Pipeline API",
     description="""""",
     version="1.0.0",
 )
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.include_router(raters_router)
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 unstructured[local-inference]>=0.4.4
 unstructured-inference>0.2.8
-unstructured_api_tools==0.4.7
+unstructured_api_tools
 
 ratelimit
 requests

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 unstructured[local-inference]>=0.4.4
-unstructured-inference>=0.2.8
+unstructured-inference>0.2.8
 unstructured_api_tools==0.4.7
 
 ratelimit

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 unstructured[local-inference]>=0.4.4
 unstructured-inference>0.2.8
-unstructured_api_tools
+unstructured_api_tools==0.5.0
 
 ratelimit
 requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,9 +51,7 @@ cycler==0.11.0
 defusedxml==0.7.1
     # via nbconvert
 deprecated==1.2.13
-    # via
-    #   argilla
-    #   limits
+    # via argilla
 effdet==0.3.0
     # via layoutparser
 et-xmlfile==1.1.0
@@ -128,8 +126,6 @@ kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
-limits==2.8.0
-    # via slowapi
 lxml==4.9.2
     # via
     #   python-docx
@@ -186,11 +182,10 @@ opencv-python==4.6.0.66
     #   unstructured-inference
 openpyxl==3.1.2
     # via unstructured
-packaging==22.0
+packaging==23.0
     # via
     #   argilla
     #   huggingface-hub
-    #   limits
     #   matplotlib
     #   nbconvert
     #   onnxruntime
@@ -299,8 +294,6 @@ six==1.16.0
     # via
     #   bleach
     #   python-dateutil
-slowapi==0.1.7
-    # via unstructured-api-tools
 sniffio==1.3.0
     # via
     #   anyio
@@ -359,7 +352,6 @@ typing-extensions==4.5.0
     # via
     #   huggingface-hub
     #   iopath
-    #   limits
     #   mypy
     #   pydantic
     #   rich
@@ -368,7 +360,7 @@ typing-extensions==4.5.0
     #   torchvision
 unstructured[local-inference]==0.5.4
     # via -r requirements/base.in
-unstructured-api-tools==0.4.7
+unstructured-api-tools==0.5.0
     # via -r requirements/base.in
 unstructured-inference==0.2.11
     # via
@@ -402,6 +394,3 @@ zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ anyio==3.6.2
     #   httpcore
     #   starlette
     #   watchfiles
-argilla==1.3.1
+argilla==1.4.0
     # via unstructured
 attrs==22.2.0
     # via jsonschema
@@ -29,7 +29,7 @@ certifi==2022.12.7
     #   unstructured
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via
     #   pdfminer-six
     #   requests
@@ -40,9 +40,11 @@ click==8.1.3
     #   uvicorn
 coloredlogs==15.0.1
     # via onnxruntime
+commonmark==0.9.1
+    # via rich
 contourpy==1.0.7
     # via matplotlib
-cryptography==39.0.1
+cryptography==39.0.2
     # via pdfminer-six
 cycler==0.11.0
     # via matplotlib
@@ -56,19 +58,19 @@ effdet==0.3.0
     # via layoutparser
 et-xmlfile==1.1.0
     # via openpyxl
-fastapi==0.92.0
+fastapi==0.94.1
     # via
     #   unstructured-api-tools
     #   unstructured-inference
 fastjsonschema==2.16.3
     # via nbformat
-filelock==3.9.0
+filelock==3.9.1
     # via
     #   huggingface-hub
     #   transformers
-flatbuffers==23.1.21
+flatbuffers==23.3.3
     # via onnxruntime
-fonttools==4.38.0
+fonttools==4.39.0
     # via matplotlib
 h11==0.14.0
     # via
@@ -80,7 +82,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via argilla
-huggingface-hub==0.12.1
+huggingface-hub==0.13.2
     # via
     #   timm
     #   transformers
@@ -95,6 +97,7 @@ idna==3.4
 importlib-metadata==6.0.0
     # via
     #   jupyter-client
+    #   markdown
     #   nbconvert
 importlib-resources==5.12.0
     # via
@@ -132,25 +135,27 @@ lxml==4.9.2
     #   python-docx
     #   python-pptx
     #   unstructured
+markdown==3.4.1
+    # via unstructured
 markupsafe==2.1.2
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.7.0
+matplotlib==3.7.1
     # via pycocotools
 mistune==2.0.5
     # via nbconvert
 monotonic==1.6
     # via argilla
-mpmath==1.2.1
+mpmath==1.3.0
     # via sympy
-mypy==1.0.1
+mypy==1.1.1
     # via unstructured-api-tools
 mypy-extensions==1.0.0
     # via mypy
 nbclient==0.7.2
     # via nbconvert
-nbconvert==7.2.9
+nbconvert==7.2.10
     # via unstructured-api-tools
 nbformat==5.7.3
     # via
@@ -179,7 +184,7 @@ opencv-python==4.6.0.66
     # via
     #   layoutparser
     #   unstructured-inference
-openpyxl==3.1.1
+openpyxl==3.1.2
     # via unstructured
 packaging==22.0
     # via
@@ -216,22 +221,26 @@ pillow==9.4.0
     #   unstructured
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via jupyter-core
 portalocker==2.7.0
     # via iopath
-protobuf==4.22.0
+protobuf==4.22.1
     # via onnxruntime
 pycocotools==2.0.6
     # via effdet
 pycparser==2.21
     # via cffi
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   argilla
     #   fastapi
 pygments==2.14.0
-    # via nbconvert
+    # via
+    #   nbconvert
+    #   rich
+pypandoc==1.11
+    # via unstructured
 pyparsing==3.0.9
     # via matplotlib
 pyrsistent==0.19.3
@@ -265,7 +274,7 @@ pyyaml==6.0
     #   timm
     #   transformers
     #   uvicorn
-pyzmq==25.0.0
+pyzmq==25.0.1
     # via jupyter-client
 ratelimit==2.2.1
     # via -r requirements/base.in
@@ -282,6 +291,8 @@ requests==2.28.2
     #   unstructured
 rfc3986[idna2008]==1.5.0
     # via httpx
+rich==13.0.1
+    # via argilla
 scipy==1.10.1
     # via layoutparser
 six==1.16.0
@@ -297,7 +308,7 @@ sniffio==1.3.0
     #   httpx
 soupsieve==2.4
     # via beautifulsoup4
-starlette==0.25.0
+starlette==0.26.1
     # via fastapi
 sympy==1.11.1
     # via onnxruntime
@@ -322,7 +333,7 @@ torchvision==0.14.1
     #   timm
 tornado==6.2
     # via jupyter-client
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   argilla
     #   huggingface-hub
@@ -351,20 +362,21 @@ typing-extensions==4.5.0
     #   limits
     #   mypy
     #   pydantic
+    #   rich
     #   starlette
     #   torch
     #   torchvision
-unstructured[local-inference]==0.4.15
+unstructured[local-inference]==0.5.4
     # via -r requirements/base.in
 unstructured-api-tools==0.4.7
     # via -r requirements/base.in
-unstructured-inference==0.2.8
+unstructured-inference==0.2.11
     # via
     #   -r requirements/base.in
     #   unstructured
-urllib3==1.26.14
+urllib3==1.26.15
     # via requests
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via
     #   unstructured-api-tools
     #   unstructured-inference
@@ -384,7 +396,7 @@ wrapt==1.14.1
     # via
     #   argilla
     #   deprecated
-xlsxwriter==3.0.8
+xlsxwriter==3.0.9
     # via python-pptx
 zipp==3.15.0
     # via

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,4 @@
-black
+black>=22.3.0
 flake8
 jupyter
 mypy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -78,7 +78,7 @@ importlib-metadata==6.0.0
     #   nbconvert
 importlib-resources==5.12.0
     # via jsonschema
-ipykernel==6.21.2
+ipykernel==6.21.3
     # via
     #   ipywidgets
     #   jupyter
@@ -127,7 +127,7 @@ jupyter-client==8.0.3
     #   nbclient
     #   notebook
     #   qtconsole
-jupyter-console==6.6.2
+jupyter-console==6.6.3
     # via jupyter
 jupyter-core==5.2.0
     # via
@@ -144,7 +144,7 @@ jupyter-core==5.2.0
     #   qtconsole
 jupyter-events==0.6.3
     # via jupyter-server
-jupyter-server==2.3.0
+jupyter-server==2.4.0
     # via
     #   nbclassic
     #   notebook-shim
@@ -166,17 +166,17 @@ mccabe==0.7.0
     # via flake8
 mistune==2.0.5
     # via nbconvert
-mypy==1.0.1
+mypy==1.1.1
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-nbclassic==0.5.2
+nbclassic==0.5.3
     # via notebook
 nbclient==0.7.2
     # via nbconvert
-nbconvert==7.2.9
+nbconvert==7.2.10
     # via
     #   jupyter
     #   jupyter-server
@@ -196,7 +196,7 @@ nest-asyncio==1.5.6
     #   ipykernel
     #   nbclassic
     #   notebook
-notebook==6.5.2
+notebook==6.5.3
     # via jupyter
 notebook-shim==0.2.2
     # via nbclassic
@@ -209,6 +209,7 @@ packaging==23.0
     #   ipykernel
     #   jupyter-server
     #   nbconvert
+    #   qtconsole
     #   qtpy
 pandocfilters==1.5.0
     # via nbconvert
@@ -220,11 +221,11 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.12.2
+pip-tools==6.12.3
     # via -r requirements/dev.in
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via
     #   black
     #   jupyter-core
@@ -233,7 +234,7 @@ prometheus-client==0.16.0
     #   jupyter-server
     #   nbclassic
     #   notebook
-prompt-toolkit==3.0.37
+prompt-toolkit==3.0.38
     # via
     #   ipython
     #   jupyter-console
@@ -271,7 +272,7 @@ pyyaml==6.0
     # via
     #   jupyter-events
     #   nbdev
-pyzmq==25.0.0
+pyzmq==25.0.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -280,7 +281,7 @@ pyzmq==25.0.0
     #   nbclassic
     #   notebook
     #   qtconsole
-qtconsole==5.4.0
+qtconsole==5.4.1
     # via jupyter
 qtpy==2.3.0
     # via qtconsole
@@ -356,7 +357,7 @@ typing-extensions==4.5.0
     #   mypy
 uri-template==1.2.0
     # via jsonschema
-watchdog==2.3.0
+watchdog==2.3.1
     # via nbdev
 wcwidth==0.2.6
     # via prompt-toolkit
@@ -368,7 +369,7 @@ webencodings==0.5.1
     #   tinycss2
 websocket-client==1.5.1
     # via jupyter-server
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   astunparse
     #   pip-tools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,4 @@
-black
+black>=22.3.0
 # NOTE(mrobinson) - Pinning click due to a unicode issue in black
 # can remove after black drops support for Python 3.6
 # ref: https://github.com/psf/black/issues/2964

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ click==8.1.3
     #   black
 coverage[toml]==7.2.1
     # via pytest-cov
-exceptiongroup==1.1.0
+exceptiongroup==1.1.1
     # via pytest
 flake8==6.0.0
     # via -r requirements/test.in
@@ -22,7 +22,7 @@ iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
-mypy==1.0.1
+mypy==1.1.1
     # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via
@@ -34,7 +34,7 @@ packaging==23.0
     #   pytest
 pathspec==0.11.0
     # via black
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via black
 pluggy==1.0.0
     # via pytest
@@ -42,7 +42,7 @@ pycodestyle==2.10.0
     # via flake8
 pyflakes==3.0.1
     # via flake8
-pytest==7.2.1
+pytest==7.2.2
     # via pytest-cov
 pytest-cov==4.0.0
     # via -r requirements/test.in

--- a/test_oer/api/test_raters.py
+++ b/test_oer/api/test_raters.py
@@ -65,7 +65,6 @@ def test_structure_oer_with_invalid_pages(invalid_pages, exception_message):
 
 def test_section_narrative_api(fake_structured_oer):
     filename = os.path.join(SAMPLE_DOCS_DIRECTORY, "fake-oer.pdf")
-    app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
         COMMENTS_ROUTE,
@@ -82,7 +81,6 @@ def test_section_narrative_api(fake_structured_oer):
 
 
 def test_section_narrative_api_with_no_file():
-    app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
         COMMENTS_ROUTE,
@@ -93,7 +91,6 @@ def test_section_narrative_api_with_no_file():
 
 def test_section_narrative_api_with_conflict_in_media_type():
     filename = os.path.join(SAMPLE_DOCS_DIRECTORY, "fake-oer.pdf")
-    app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
         COMMENTS_ROUTE,
@@ -109,7 +106,6 @@ def test_section_narrative_api_with_conflict_in_media_type():
 
 def test_section_narrative_api_with_multiple_files():
     filename = os.path.join(SAMPLE_DOCS_DIRECTORY, "fake-oer.pdf")
-    app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
         COMMENTS_ROUTE,


### PR DESCRIPTION
Bump dependencies, including `unstructured` / `unstructured-inference` to take advantage of fixes and new inference techniques. Also updated install order in the `Makefile` to make sure the correct version of `black` is installed.