### PR TITLE
chore: update all bash scripts to use shebang: /usr/bin/env bash

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 find scripts -name "*.sh" -exec shellcheck {} +
 


### PR DESCRIPTION
Update all bash scripts with #!/bin/bash to use /usr/bin/env bash.
